### PR TITLE
support doubles as target in mapping

### DIFF
--- a/src/Sushi.MicroORM/Supporting/ReflectionHelper.cs
+++ b/src/Sushi.MicroORM/Supporting/ReflectionHelper.cs
@@ -184,8 +184,13 @@ namespace Sushi.MicroORM.Supporting
                 value = DateTime.SpecifyKind(dt, dateTimeKind.Value);
             }
 
+            // convert between double/decimal
+            if (targetType == typeof(double) && value is decimal d)
+            {
+                value = Convert.ToDouble(d);
+            }
             // custom support for converting to DateOnly and TimeOnly
-            if (targetType == typeof(DateOnly) && value is DateTime dt1)
+            else if (targetType == typeof(DateOnly) && value is DateTime dt1)
             {
                 value = DateOnly.FromDateTime(dt1);
             }

--- a/src/Sushi.MicroORM/Sushi.MicroORM.csproj
+++ b/src/Sushi.MicroORM/Sushi.MicroORM.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.1.0-beta.12</Version>
+    <Version>3.1.0-beta.13</Version>
     <Authors>Supershift B.V.</Authors>    
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>    
     <Description>Simple and high performance micro-ORM. Supports SQL Azure and SQL Server 2012 and higher.</Description>    

--- a/tests/Sushi.MicroORM.UnitTests/ReflectionHelperTest.cs
+++ b/tests/Sushi.MicroORM.UnitTests/ReflectionHelperTest.cs
@@ -5,6 +5,21 @@ namespace Sushi.MicroORM.UnitTests
 {
     public class ReflectionHelperTest
     {
+        [Fact]
+        public void SetDoubleFromDecimal()
+        {
+            // arrange
+            var instance = new TestClass();
+            decimal value = 12.46M;
+            var memberTree = ReflectionHelper.GetMemberTree<TestClass>(x => x.DoubleValue);
+
+            // act
+            ReflectionHelper.SetMemberValue(memberTree, value, instance, null);
+
+            // assert            
+            Assert.Equal(decimal.ToDouble(value), instance.DoubleValue);
+        }
+
         [Theory]
         [InlineData(DateTimeKind.Utc)]
         [InlineData(DateTimeKind.Unspecified)]
@@ -138,6 +153,7 @@ namespace Sushi.MicroORM.UnitTests
             public SubTestClass SubProperty { get; set; } = null!;
             public SubTestClass? NullableSubProperty { get; set; }
             public SubTestClass? NullableSubField = null;
+            public double? DoubleValue { get; set; }
         }
 
         private class SubTestClass


### PR DESCRIPTION
Sql Server only has a 'decimal' type. Requires explicit convert, because a double cannot be set from decimal. 